### PR TITLE
Fix pickable issue

### DIFF
--- a/tests/test_iris_hypothetic.py
+++ b/tests/test_iris_hypothetic.py
@@ -4,3 +4,20 @@ import pytest
 
 def test_import():
     from iris_hypothetic import load_hypotheticube
+
+
+def teat_pickle():
+    from iris_hypothetic import CheckingNetCDFDataProxy
+    import pickle
+    import numpy as np
+
+    shape = (3, 970, 1042)
+    dtype = 'float32'
+    path = "s3://informatics-webimages/0002093217dad7e7c21011f13bff4b1eac270f6a.nc"
+    var_name = 'cloud_base_altitude_assuming_only_consider_cloud_area_fraction_greater_than_4p5_oktas'
+
+    p = CheckingNetCDFDataProxy(shape, dtype, path, var_name)
+    before = p[0, 0]
+    pickled = pickle.dumps(p)
+    after = pickle.loads(pickled)[0, 0]
+    np.testing.assert_array_equal(before, after)


### PR DESCRIPTION
Working on a cluster often fails with errors like:
```

distributed.protocol.pickle - INFO - Failed to serialize <CheckingNetCDFDataProxy shape=(3, 970, 1042) dtype=dtype('float32') path='s3://informatics-aws-earth-staging/000022ebcaa274042be4b353fb228a8660d04072.nc' variable_name='rainfall_rate'>. Exception: cannot serialize '_io.BufferedRandom' object
```
By implementing a custom seralisation that removes the tempfile handel should resolve this.
