### PR TITLE
Remove 'bye'

### DIFF
--- a/iris_hypothetic/__init__.py
+++ b/iris_hypothetic/__init__.py
@@ -12,7 +12,6 @@ import numpy as np
 import numpy.ma as ma
 import netCDF4
 import iris
-print('bye')
 
 __version__ = get_versions()['version']
 del get_versions


### PR DESCRIPTION
To stop `'bye'` being printed every time 'intake' is used